### PR TITLE
Load EitherTypeAdapterFactory for registration

### DIFF
--- a/core/che-core-api-dto/pom.xml
+++ b/core/che-core-api-dto/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.lsp4j</groupId>
-            <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -33,6 +33,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -41,7 +42,6 @@ import org.eclipse.che.commons.lang.reflect.ParameterizedTypeImpl;
 import org.eclipse.che.dto.shared.DTO;
 import org.eclipse.che.dto.shared.JsonArray;
 import org.eclipse.che.dto.shared.JsonStringMap;
-import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory;
 
 /**
  * Provides implementations of DTO interfaces.
@@ -102,13 +102,11 @@ public final class DtoFactory {
   // It helps avoid reflection when need create copy of exited DTO instance.
   private final Map<Class<?>, DtoProvider<?>> dtoImpl2Providers = new ConcurrentHashMap<>();
   private final Gson dtoGson =
-      new GsonBuilder()
-          .registerTypeAdapterFactory(
-              new NullAsEmptyTAF<>(Collection.class, Collections.emptyList()))
-          .registerTypeAdapterFactory(new NullAsEmptyTAF<>(Map.class, Collections.emptyMap()))
-          .registerTypeAdapterFactory(new DtoInterfaceTAF())
-          .registerTypeAdapterFactory(new EitherTypeAdapterFactory())
-          .create();
+      buildDtoParser(
+          ServiceLoader.load(TypeAdapterFactory.class).iterator(),
+          new NullAsEmptyTAF<>(Collection.class, Collections.emptyList()),
+          new NullAsEmptyTAF<>(Map.class, Collections.emptyMap()),
+          new DtoInterfaceTAF());
 
   /**
    * Created deep copy of DTO object.
@@ -492,4 +490,19 @@ public final class DtoFactory {
   }
 
   private DtoFactory() {}
+
+  private static Gson buildDtoParser(
+      Iterator<TypeAdapterFactory> factoryIterator, TypeAdapterFactory... factories) {
+    GsonBuilder builder = new GsonBuilder();
+
+    for (Iterator<TypeAdapterFactory> it = factoryIterator; it.hasNext(); ) {
+      TypeAdapterFactory factory = it.next();
+      builder.registerTypeAdapterFactory(factory);
+    }
+
+    for (TypeAdapterFactory factory : factories) {
+      builder.registerTypeAdapterFactory(factory);
+    }
+    return builder.create();
+  }
 }

--- a/wsagent/che-core-api-languageserver/src/main/resources/META-INF/services/com.google.gson.TypeAdapterFactory
+++ b/wsagent/che-core-api-languageserver/src/main/resources/META-INF/services/com.google.gson.TypeAdapterFactory
@@ -1,0 +1,1 @@
+org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory


### PR DESCRIPTION
Make it possible to register EitherTypeAdapterFactory without adding dependency of lsp4j to the dto generation module.